### PR TITLE
Fix pagination reset bug in blog index

### DIFF
--- a/pages/blogs/index.vue
+++ b/pages/blogs/index.vue
@@ -19,6 +19,24 @@ const searchQuery = ref('')
  */
 const selectedCategories = ref<string[]>([])
 
+/**
+ * Reset to the first page whenever the search query changes
+ */
+watch(searchQuery, () => {
+  pageNumber.value = 1
+})
+
+/**
+ * Reset to the first page whenever the selected categories change
+ */
+watch(
+  selectedCategories,
+  () => {
+    pageNumber.value = 1
+  },
+  { deep: true },
+)
+
 // Initialize selected categories from URL query parameters
 onMounted(() => {
   const categoriesParam = route.query.categories as string


### PR DESCRIPTION
## Summary
- reset pagination when search query or selected categories change

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/aaronguoblog/.nuxt/eslint.config.mjs')*
