### PR TITLE
Fix blog pages to reload content on route changes

### DIFF
--- a/pages/blogs/[...blog].vue
+++ b/pages/blogs/[...blog].vue
@@ -5,22 +5,19 @@ import { navbarData, seoData } from '~/data'
 const route = useRoute()
 const { locale } = useI18n()
 
-// Extract the path from the route
-const { path } = route
-
 // Determine the correct collection and content path
 const collection = computed(() => locale.value)
 
 // Transform the URL path to the content path
 const contentPath = computed(() => {
   // Extract the blog slug from the URL path
-  let blogSlug = path
+  let blogSlug = route.path
 
   // Remove language prefix if present
-  if (path.startsWith('/zh/blogs/')) {
-    blogSlug = path.replace('/zh/blogs/', '')
-  } else if (path.startsWith('/blogs/')) {
-    blogSlug = path.replace('/blogs/', '')
+  if (route.path.startsWith('/zh/blogs/')) {
+    blogSlug = route.path.replace('/zh/blogs/', '')
+  } else if (route.path.startsWith('/blogs/')) {
+    blogSlug = route.path.replace('/blogs/', '')
   }
 
   // Construct the content path based on the collection and slug
@@ -29,10 +26,15 @@ const contentPath = computed(() => {
 
 console.log('Content path:', contentPath.value)
 
-const { data: articles, error } = await useAsyncData(`blog-post-${path}`, () =>
-  queryCollection(collection.value as 'en' | 'zh')
-    .path(contentPath.value)
-    .first(),
+const { data: articles, error } = await useAsyncData(
+  `blog-post-${route.path}`,
+  () =>
+    queryCollection(collection.value as 'en' | 'zh')
+      .path(contentPath.value)
+      .first(),
+  {
+    watch: [() => route.path],
+  },
 )
 
 if (error.value) navigateTo('/404')
@@ -66,7 +68,7 @@ useHead({
     { property: 'og:type', content: 'website' },
     {
       property: 'og:url',
-      content: `${seoData.mySite}/${path}`,
+      content: `${seoData.mySite}/${route.path}`,
     },
     {
       property: 'og:title',
@@ -85,7 +87,7 @@ useHead({
     { name: 'twitter:card', content: 'summary_large_image' },
     {
       name: 'twitter:url',
-      content: `${seoData.mySite}/${path}`,
+      content: `${seoData.mySite}/${route.path}`,
     },
     {
       name: 'twitter:title',
@@ -103,7 +105,7 @@ useHead({
   link: [
     {
       rel: 'canonical',
-      href: `${seoData.mySite}/${path}`,
+      href: `${seoData.mySite}/${route.path}`,
     },
   ],
 })

--- a/pages/blogs/[blog].vue
+++ b/pages/blogs/[blog].vue
@@ -5,22 +5,19 @@ import { navbarData, seoData } from '~/data'
 const route = useRoute()
 const { locale } = useI18n()
 
-// Extract the path from the route
-const { path } = route
-
 // Determine the correct collection and content path
 const collection = computed(() => locale.value)
 
 // Transform the URL path to the content path
 const contentPath = computed(() => {
   // Extract the blog slug from the URL path
-  let blogSlug = path
+  let blogSlug = route.path
 
   // Remove language prefix if present
-  if (path.startsWith('/zh/blogs/')) {
-    blogSlug = path.replace('/zh/blogs/', '')
-  } else if (path.startsWith('/blogs/')) {
-    blogSlug = path.replace('/blogs/', '')
+  if (route.path.startsWith('/zh/blogs/')) {
+    blogSlug = route.path.replace('/zh/blogs/', '')
+  } else if (route.path.startsWith('/blogs/')) {
+    blogSlug = route.path.replace('/blogs/', '')
   }
 
   // Construct the content path based on the collection and slug
@@ -29,10 +26,15 @@ const contentPath = computed(() => {
 
 console.log('Content path:', contentPath.value)
 
-const { data: articles, error } = await useAsyncData(`blog-post-${path}`, () =>
-  queryCollection(collection.value as 'en' | 'zh')
-    .path(contentPath.value)
-    .first(),
+const { data: articles, error } = await useAsyncData(
+  `blog-post-${route.path}`,
+  () =>
+    queryCollection(collection.value as 'en' | 'zh')
+      .path(contentPath.value)
+      .first(),
+  {
+    watch: [() => route.path],
+  },
 )
 
 if (error.value) navigateTo('/404')
@@ -66,7 +68,7 @@ useHead({
     { property: 'og:type', content: 'website' },
     {
       property: 'og:url',
-      content: `${seoData.mySite}/${path}`,
+      content: `${seoData.mySite}/${route.path}`,
     },
     {
       property: 'og:title',
@@ -85,7 +87,7 @@ useHead({
     { name: 'twitter:card', content: 'summary_large_image' },
     {
       name: 'twitter:url',
-      content: `${seoData.mySite}/${path}`,
+      content: `${seoData.mySite}/${route.path}`,
     },
     {
       name: 'twitter:title',
@@ -103,7 +105,7 @@ useHead({
   link: [
     {
       rel: 'canonical',
-      href: `${seoData.mySite}/${path}`,
+      href: `${seoData.mySite}/${route.path}`,
     },
   ],
 })


### PR DESCRIPTION
## Summary
- fetch blog content using `route.path` instead of the extracted `path`
- allow `useAsyncData` to refetch when the route changes

## Testing
- `npm run lint` *(fails: cannot find module `.nuxt/eslint.config.mjs`)*
- `npm run format`
- `npm run build` *(fails: `nuxt` not found)*